### PR TITLE
Add GitHub Actions workflow for ci & code coverage

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "main"
+      - "*-ci"
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.x
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install sympy coverage pytest matplotlib
+
+      - name: Run tests
+        run: |
+          coverage run -m pytest GridPythonModule_test.py -v
+          coverage report -m


### PR DESCRIPTION
The workflow will be triggered on both push and pull request to `main `and `*-ci` branches

After merging this PR, the Github Actions of this repository should look like [this](https://github.com/kamalsaleh/GridPythonModule/actions/runs/6923281132/job/18830985135). The report will be available under the `Run Tests` item.

If everything went well, then there will be no need for the file `full_coverage_report.txt` ;)